### PR TITLE
Fix license headers to match LGPLv2.1

### DIFF
--- a/src/btrfs.c
+++ b/src/btrfs.c
@@ -3,16 +3,16 @@
  * This file is part of btrfs-efi.
  *
  * btrfs-efi is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public Licence as published by
- * the Free Software Foundation, either version 3 of the Licence, or
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the License, or
  * (at your option) any later version.
  *
  * btrfs-efi is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public Licence for more details.
+ * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public Licence
+ * You should have received a copy of the GNU Lesser General Public License
  * along with btrfs-efi.  If not, see <http://www.gnu.org/licenses/>. */
 
 #include <efibind.h>

--- a/src/crc32c.c
+++ b/src/crc32c.c
@@ -3,16 +3,16 @@
  * This file is part of btrfs-efi.
  *
  * btrfs-efi is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public Licence as published by
- * the Free Software Foundation, either version 3 of the Licence, or
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the License, or
  * (at your option) any later version.
  *
  * btrfs-efi is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public Licence for more details.
+ * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public Licence
+ * You should have received a copy of the GNU Lesser General Public License
  * along with btrfs-efi.  If not, see <http://www.gnu.org/licenses/>. */
 
 #include <stdint.h>

--- a/src/lzo.c
+++ b/src/lzo.c
@@ -3,16 +3,16 @@
  * This file is part of btrfs-efi.
  *
  * btrfs-efi is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public Licence as published by
- * the Free Software Foundation, either version 3 of the Licence, or
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the License, or
  * (at your option) any later version.
  *
  * btrfs-efi is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public Licence for more details.
+ * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public Licence
+ * You should have received a copy of the GNU Lesser General Public License
  * along with btrfs-efi.  If not, see <http://www.gnu.org/licenses/>. */
 
 // This LZO compression code comes from v0.22 of lzo, written way back in

--- a/src/misc.c
+++ b/src/misc.c
@@ -3,16 +3,16 @@
  * This file is part of btrfs-efi.
  *
  * btrfs-efi is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public Licence as published by
- * the Free Software Foundation, either version 3 of the Licence, or
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the License, or
  * (at your option) any later version.
  *
  * btrfs-efi is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public Licence for more details.
+ * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public Licence
+ * You should have received a copy of the GNU Lesser General Public License
  * along with btrfs-efi.  If not, see <http://www.gnu.org/licenses/>. */
 
 #include "misc.h"

--- a/src/misc.h
+++ b/src/misc.h
@@ -3,16 +3,16 @@
  * This file is part of btrfs-efi.
  *
  * btrfs-efi is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public Licence as published by
- * the Free Software Foundation, either version 3 of the Licence, or
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the License, or
  * (at your option) any later version.
  *
  * btrfs-efi is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public Licence for more details.
+ * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public Licence
+ * You should have received a copy of the GNU Lesser General Public License
  * along with btrfs-efi.  If not, see <http://www.gnu.org/licenses/>. */
 
 #pragma once

--- a/src/quibbleproto.h
+++ b/src/quibbleproto.h
@@ -3,16 +3,16 @@
  * This file is part of btrfs-efi.
  *
  * btrfs-efi is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public Licence as published by
- * the Free Software Foundation, either version 3 of the Licence, or
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the License, or
  * (at your option) any later version.
  *
  * btrfs-efi is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public Licence for more details.
+ * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public Licence
+ * You should have received a copy of the GNU Lesser General Public License
  * along with btrfs-efi.  If not, see <http://www.gnu.org/licenses/>. */
 
 #pragma once


### PR DESCRIPTION
The license was downgraded to LGPL-2.1-or-later some time ago, but the license headers were not updated accordingly.

Fixes: 0059982df5 ("change to LGPL 2.1")